### PR TITLE
Add Roborock-style vacuum modes

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,6 +46,10 @@ If you like this project and find it useful, please consider giving it a star on
 - All commands (npm, tsc, matterbridge etc.) will run inside the container environment.
 - Since the dev container doesn't have network host and IPV6, is not possible to pair matterbridge from the Devcontainer but you can add your plugin to matterbridge and test it inside the devcontainer.
 
+## Example: Virtual Robot Vacuum
+
+This template now includes an example of how to register a virtual robotic vacuum cleaner. The vacuum exposes clusters for run mode, clean mode and operational state and logs simple messages when commands like `changeToMode`, `pause`, `resume` or `goHome` are received. Supported run and clean modes are modelled after the Roborock S5. The example also defines service areas for **Kitchen**, **Living Room**, **Master Bedroom**, **Second Bedroom**, **Dressing** and **Entryway**. Check `src/module.ts` for the implementation details.
+
 ## Documentation
 
 Refer to the Matterbridge documentation for other guidelines.

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,4 +1,12 @@
-import { Matterbridge, MatterbridgeDynamicPlatform, MatterbridgeEndpoint, onOffOutlet, PlatformConfig } from 'matterbridge';
+import {
+  Matterbridge,
+  MatterbridgeDynamicPlatform,
+  MatterbridgeEndpoint,
+  onOffOutlet,
+  PlatformConfig,
+  RoboticVacuumCleaner,
+} from 'matterbridge';
+import { RvcRunMode, RvcCleanMode, ServiceArea } from '@matter/main/clusters';
 import { AnsiLogger, LogLevel } from 'matterbridge/logger';
 
 /**
@@ -105,5 +113,78 @@ export class TemplatePlatform extends MatterbridgeDynamicPlatform {
       });
 
     await this.registerDevice(outlet);
+
+    // Example: Create and register a robotic vacuum cleaner device
+    const runModes: RvcRunMode.ModeOption[] = [
+      { label: 'Idle', mode: 1, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },
+      { label: 'Quiet', mode: 2, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
+      { label: 'Balanced', mode: 3, modeTags: [{ value: RvcRunMode.ModeTag.Cleaning }] },
+      {
+        label: 'Turbo',
+        mode: 4,
+        modeTags: [
+          { value: RvcRunMode.ModeTag.Cleaning },
+          { value: RvcRunMode.ModeTag.Max },
+        ],
+      },
+      {
+        label: 'Max',
+        mode: 5,
+        modeTags: [
+          { value: RvcRunMode.ModeTag.Cleaning },
+          { value: RvcRunMode.ModeTag.Max },
+        ],
+      },
+    ];
+
+    const cleanModes: RvcCleanMode.ModeOption[] = [
+      { label: 'Vacuum', mode: 1, modeTags: [{ value: RvcCleanMode.ModeTag.Vacuum }] },
+      { label: 'Mop', mode: 2, modeTags: [{ value: RvcCleanMode.ModeTag.Mop }] },
+      {
+        label: 'Vacuum and Mop',
+        mode: 3,
+        modeTags: [
+          { value: RvcCleanMode.ModeTag.Vacuum },
+          { value: RvcCleanMode.ModeTag.Mop },
+        ],
+      },
+    ];
+
+    const serviceAreas: ServiceArea.Area[] = [
+      { areaId: 1, mapId: null, areaInfo: { locationInfo: { locationName: 'Kitchen', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 2, mapId: null, areaInfo: { locationInfo: { locationName: 'Living Room', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 3, mapId: null, areaInfo: { locationInfo: { locationName: 'Master Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 4, mapId: null, areaInfo: { locationInfo: { locationName: 'Second Bedroom', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 5, mapId: null, areaInfo: { locationInfo: { locationName: 'Dressing', floorNumber: null, areaType: null }, landmarkInfo: null } },
+      { areaId: 6, mapId: null, areaInfo: { locationInfo: { locationName: 'Entryway', floorNumber: null, areaType: null }, landmarkInfo: null } },
+    ];
+
+    const vacuum = new RoboticVacuumCleaner(
+      'Virtual Vacuum',
+      'VV123',
+      1,
+      runModes,
+      1,
+      cleanModes,
+      null,
+      null,
+      undefined,
+      undefined,
+      serviceAreas,
+    )
+      .addCommandHandler('changeToMode', (data) => {
+        this.log.info(`Vacuum changeToMode called with: ${JSON.stringify(data.request)}`);
+      })
+      .addCommandHandler('pause', () => {
+        this.log.info('Vacuum pause command received');
+      })
+      .addCommandHandler('resume', () => {
+        this.log.info('Vacuum resume command received');
+      })
+      .addCommandHandler('goHome', () => {
+        this.log.info('Vacuum goHome command received');
+      });
+
+    await this.registerDevice(vacuum);
   }
 }


### PR DESCRIPTION
## Summary
- refine robotic vacuum example with Roborock S5-style modes
- document new modes and rooms in the README

## Testing
- `npm test` *(fails: Cannot find module '@matter/main/platform')*


------
https://chatgpt.com/codex/tasks/task_e_6856792f5220832b9a7066d2b8d01286