### PR TITLE
Add MDNS discovery and handshake

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       "devDependencies": {
         "@eslint/js": "^9.29.0",
         "@types/jest": "^30.0.0",
+        "@types/multicast-dns": "^7.2.4",
         "@types/node": "^24.0.3",
         "@vitest/coverage-v8": "^3.2.4",
         "@vitest/eslint-plugin": "^1.2.7",
@@ -2171,6 +2172,15 @@
       "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
       "dev": true
     },
+    "node_modules/@types/dns-packet": {
+      "version": "5.6.5",
+      "resolved": "https://registry.npmjs.org/@types/dns-packet/-/dns-packet-5.6.5.tgz",
+      "integrity": "sha512-qXOC7XLOEe43ehtWJCMnQXvgcIpv6rPmQ1jXT98Ad8A3TB1Ue50jsCbSSSyuazScEuZ/Q026vHbrOTVkmwA+7Q==",
+      "dev": true,
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -2223,6 +2233,16 @@
       "resolved": "https://registry.npmjs.org/@types/json5/-/json5-0.0.29.tgz",
       "integrity": "sha512-dRLjCWHYg4oaA77cxO64oO+7JwCwnIzkZPdrrC71jQmQtlhM556pwKo5bUzqvZndkVbeFLIIi+9TC40JNF5hNQ==",
       "dev": true
+    },
+    "node_modules/@types/multicast-dns": {
+      "version": "7.2.4",
+      "resolved": "https://registry.npmjs.org/@types/multicast-dns/-/multicast-dns-7.2.4.tgz",
+      "integrity": "sha512-ib5K4cIDR4Ro5SR3Sx/LROkMDa0BHz0OPaCBL/OSPDsAXEGZ3/KQeS6poBKYVN7BfjXDL9lWNwzyHVgt/wkyCw==",
+      "dev": true,
+      "dependencies": {
+        "@types/dns-packet": "*",
+        "@types/node": "*"
+      }
     },
     "node_modules/@types/node": {
       "version": "24.0.3",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,14 +1,15 @@
 {
   "name": "matterbridge-plugin-template",
-  "version": "1.0.5",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "matterbridge-plugin-template",
-      "version": "1.0.5",
+      "version": "1.0.1",
       "license": "Apache-2.0",
       "dependencies": {
+        "multicast-dns": "^7.2.5",
         "node-ansi-logger": "^3.0.1",
         "node-persist-manager": "^2.0.0"
       },
@@ -34,10 +35,6 @@
       },
       "engines": {
         "node": ">=18.0.0 <19.0.0 || >=20.0.0 <21.0.0 || >=22.0.0 <23.0.0 || >=24.0.0 <25.0.0"
-      },
-      "funding": {
-        "type": "buymeacoffee",
-        "url": "https://www.buymeacoffee.com/luligugithub"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1742,6 +1739,12 @@
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
       }
+    },
+    "node_modules/@leichtgewicht/ip-codec": {
+      "version": "2.0.5",
+      "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
+      "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw==",
+      "license": "MIT"
     },
     "node_modules/@napi-rs/wasm-runtime": {
       "version": "0.2.11",
@@ -3867,6 +3870,18 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/dns-packet": {
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/dns-packet/-/dns-packet-5.6.1.tgz",
+      "integrity": "sha512-l4gcSouhcgIKRvyy99RNVOgxXiicE+2jZoNmaNmZ6JXiGajBOJAesk1OBlJuM5k2c+eudGdLxDqXuPCKIj6kpw==",
+      "license": "MIT",
+      "dependencies": {
+        "@leichtgewicht/ip-codec": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=6"
       }
     },
     "node_modules/doctrine": {
@@ -6782,6 +6797,19 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "dev": true
     },
+    "node_modules/multicast-dns": {
+      "version": "7.2.5",
+      "resolved": "https://registry.npmjs.org/multicast-dns/-/multicast-dns-7.2.5.tgz",
+      "integrity": "sha512-2eznPJP8z2BFLX50tf0LuODrpINqP1RVIm/CObbTcBRITQgmC/TjcREF1NeTBzIcR5XO/ukWo+YHOjBbFwIupg==",
+      "license": "MIT",
+      "dependencies": {
+        "dns-packet": "^5.2.2",
+        "thunky": "^1.0.2"
+      },
+      "bin": {
+        "multicast-dns": "cli.js"
+      }
+    },
     "node_modules/nanoid": {
       "version": "3.3.11",
       "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
@@ -8254,6 +8282,12 @@
       "engines": {
         "node": ">=18"
       }
+    },
+    "node_modules/thunky": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
+      "integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
+      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
   "bugs": {
     "url": "https://github.com/veonua/matterbridge-plugin-template/issues"
   },
-  
   "keywords": [
     "matterbridge",
     "plugin",
@@ -93,6 +92,7 @@
     "vitest": "^3.2.4"
   },
   "dependencies": {
+    "multicast-dns": "^7.2.5",
     "node-ansi-logger": "^3.0.1",
     "node-persist-manager": "^2.0.0"
   }

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "roborock-matterbridge-plugin",
-  "version": "1.0.11",
+  "version": "1.0.14",
   "description": "Roborock Matterbridge Plugin",
   "author": "https://github.com/veonua",
   "homepage": "https://github.com/veonua/matterbridge-plugin-template/blob/main/README.md",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "matterbridge-plugin-template",
-  "version": "1.0.1",
+  "name": "roborock-matterbridge-plugin",
+  "version": "1.0.11",
   "description": "Roborock Matterbridge Plugin",
   "author": "https://github.com/veonua",
   "homepage": "https://github.com/veonua/matterbridge-plugin-template/blob/main/README.md",
@@ -74,6 +74,7 @@
   "devDependencies": {
     "@eslint/js": "^9.29.0",
     "@types/jest": "^30.0.0",
+    "@types/multicast-dns": "^7.2.4",
     "@types/node": "^24.0.3",
     "@vitest/coverage-v8": "^3.2.4",
     "@vitest/eslint-plugin": "^1.2.7",

--- a/src/module.ts
+++ b/src/module.ts
@@ -2,7 +2,7 @@ import { Matterbridge, MatterbridgeDynamicPlatform, PlatformConfig, RoboticVacuu
 import { RvcRunMode, RvcCleanMode, ServiceArea, RvcOperationalState } from 'matterbridge/matter/clusters';
 import { AnsiLogger, LogLevel } from 'matterbridge/logger';
 
-import { RoborockClient } from './roborock.js';
+import { RoborockClient } from './roborock.ts';
 
 /**
  MDNS discovery example for Roborock S5 vacuum cleaner.
@@ -165,8 +165,14 @@ export class TemplatePlatform extends MatterbridgeDynamicPlatform {
   private async discoverDevices() {
     this.log.info('Discovering devices...');
 
-    this.roborock = new RoborockClient('192.168.1.100', 1234567890, '00000000000000000000000000000000');
-    await this.roborock.handshake();
+    const info = await RoborockClient.discover();
+    if (!info) {
+      this.log.warn('No Roborock devices found via mDNS');
+      return;
+    }
+    const { host, serialNumber, model } = info;
+    this.log.info(`Discovered ${model} (${serialNumber}) at ${host}`);
+    this.roborock = new RoborockClient(host, Number(serialNumber), '00000000000000000000000000000000');
 
     const runModes: RvcRunMode.ModeOption[] = [
       { label: 'Idle', mode: 1, modeTags: [{ value: RvcRunMode.ModeTag.Idle }] },

--- a/src/roborock.ts
+++ b/src/roborock.ts
@@ -1,15 +1,63 @@
 import dgram from 'dgram';
+import { resolve4 } from 'node:dns/promises';
+import mdns from 'multicast-dns';
 import { Packet } from './packet.js';
 
 export class RoborockClient {
   private socket = dgram.createSocket('udp4');
   private packet: Packet;
+  static async discover(timeout = 1000): Promise<{
+    model: string;
+    serialNumber: string;
+    host: string;
+  } | undefined> {
+    const m = mdns();
+    return new Promise((resolve) => {
+      const devices = new Map<string, { model: string; serialNumber: string; host: string }>();
+      const pending: Promise<void>[] = [];
+      const finish = () => {
+        Promise.all(pending).then(() => {
+          m.destroy();
+          resolve(devices.values().next().value);
+        });
+      };
+      const timer = setTimeout(finish, timeout);
+      m.on('response', (resp) => {
+        for (const answer of resp.answers) {
+          if (answer.type === 'PTR' && answer.name === '_miio._udp.local') {
+            const serviceName = String(answer.data);
+            if (!devices.has(serviceName)) {
+              const match = serviceName.match(/^(.*)_miio(\d+)\._miio\._udp\.local$/);
+              if (match) {
+                const [, model, serialNumber] = match;
+                const p = resolve4(serviceName)
+                  .then((addresses) => {
+                    if (addresses && addresses[0]) {
+                      devices.set(serviceName, { model, serialNumber, host: addresses[0] });
+                    }
+                  })
+                  .catch(() => {});
+                pending.push(p);
+              }
+            }
+          }
+        }
+      });
+      m.query([{ name: '_miio._udp.local', type: 'PTR' }]);
+    });
+  }
   constructor(
     private host: string,
     private deviceId: number,
     token: string,
   ) {
     this.packet = new Packet(deviceId, token);
+  }
+
+  private async ensureHandshake() {
+    if (this.packet.needsHandshake) {
+      await this.handshake();
+    }
   }
 
   async handshake() {
@@ -23,6 +71,7 @@ export class RoborockClient {
   }
 
   async sendCommand(method: string, params?: any[]) {
+    await this.ensureHandshake();
     const buf = this.packet.encode({ method, params });
     await new Promise<void>((resolve, reject) => {
       this.socket.send(buf, 0, buf.length, 54321, this.host, (err) => {

--- a/src/roborock.ts
+++ b/src/roborock.ts
@@ -2,6 +2,7 @@ import dgram from 'node:dgram';
 import { resolve4 } from 'node:dns/promises';
 
 import mdns from 'multicast-dns';
+import { AnsiLogger } from 'node-ansi-logger';
 
 import { Packet } from './packet.js';
 import { IFanPower } from './types.js';
@@ -9,7 +10,7 @@ import { IFanPower } from './types.js';
 export class RoborockClient {
   private socket = dgram.createSocket('udp4');
   private packet: Packet;
-  static async discover(timeout = 3000): Promise<
+  static async discover(log: AnsiLogger, timeout = 3000): Promise<
     | {
         model: string;
         serialNumber: string;
@@ -29,20 +30,25 @@ export class RoborockClient {
       };
       const timer = setTimeout(finish, timeout);
       m.on('response', (resp: { answers: Array<{ type: string; name: string; data: unknown }> }) => {
+        log.debug(`mDNS response: ${JSON.stringify(resp)}`);
         for (const answer of resp.answers) {
           if (answer.type === 'PTR' && answer.name === '_miio._udp.local') {
             const serviceName = String(answer.data);
             if (!devices.has(serviceName)) {
+              log.info(`Discovered service: ${serviceName}`);
               const match = serviceName.match(/^(.*)_miio(\d+)\._miio\._udp\.local$/);
               if (match) {
                 const [, model, serialNumber] = match;
                 const p = resolve4(serviceName)
                   .then((addresses: string[]) => {
+                    log.info(`Resolved ${serviceName} to addresses: ${addresses.join(', ')}`);
                     if (addresses && addresses[0]) {
                       devices.set(serviceName, { model, serialNumber, host: addresses[0] });
                     }
                   })
-                  .catch(() => {});
+                  .catch(() => {
+                    log.warn(`Failed to resolve ${serviceName}`);
+                  });
                 pending.push(p);
               }
             }
@@ -53,10 +59,12 @@ export class RoborockClient {
     });
   }
   constructor(
+    private log: AnsiLogger,
     private host: string,
     private deviceId: number,
     token: string,
   ) {
+    this.log = log;
     this.packet = new Packet(deviceId, token);
   }
 
@@ -67,11 +75,17 @@ export class RoborockClient {
   }
 
   async handshake() {
+    this.log.info(`Sending handshake to ${this.host}`);
     const msg = Buffer.from(this.packet.handshake, 'hex');
     await new Promise<void>((resolve, reject) => {
       this.socket.send(msg, 0, msg.length, 54321, this.host, (err) => {
-        if (err) reject(err);
-        else resolve();
+        if (err) {
+          this.log.error(`Handshake failed: ${err.message}`);
+          reject(err);
+        } else {
+          this.log.info(`Handshake successful with ${this.host}`);
+          resolve();
+        }
       });
     });
   }
@@ -81,8 +95,13 @@ export class RoborockClient {
     const buf = this.packet.encode({ method, params });
     await new Promise<void>((resolve, reject) => {
       this.socket.send(buf, 0, buf.length, 54321, this.host, (err) => {
-        if (err) reject(err);
-        else resolve();
+        if (err) {
+          this.log.error(`Failed to send command ${method} to ${this.host}: ${err.message}`);
+          reject(err);
+        } else {
+          this.log.info(`Command ${method} sent to ${this.host}`);
+          resolve();
+        }
       });
     });
   }


### PR DESCRIPTION
## Summary
- add `multicast-dns` dependency
- scan `_miio._udp.local` to discover Roborock devices
- automatically log discovered model and serial number and use it for the client
- ensure handshake before commands
- fix local import path

## Testing
- `npm test` *(fails: Cannot find module 'matterbridge/logger')*

------
https://chatgpt.com/codex/tasks/task_e_6858583af560832b82bea09e87249ab2