### PR TITLE
Add room cleaning command

### DIFF
--- a/src/miio.d.ts
+++ b/src/miio.d.ts
@@ -80,9 +80,11 @@ declare module 'miio' {
      * @param method - The method name to call
      * @param args - Arguments to pass to the method
      * @param options - Additional options for the call
+     * @param options.refresh - Properties to refresh after the call
+     * @param options.refreshDelay - Delay in milliseconds before refreshing
      * @returns Promise that resolves to the method result
      */
-    call(method: string, args?: any[], options?: { refresh?: string[]; refreshDelay?: number }): Promise<any>;
+    call(method: string, args?: unknown[], options?: { refresh?: string[]; refreshDelay?: number }): Promise<unknown>;
 
     /**
      * Start cleaning
@@ -184,26 +186,26 @@ declare module 'miio' {
   /**
    * Connect to a miio device
    *
-   * @param options - Connection options including address and token
-   * @returns Promise that resolves to a Device instance
+   * @param {DeviceOptions} options - Connection options including address and token
+   * @returns {Promise<MiioDevice>} Promise that resolves to a Device instance
    */
   export function device(options: DeviceOptions): Promise<MiioDevice>;
 
   /**
    * Get multiple devices
    *
-   * @param options - Options for getting devices, e.g., cache time
-   * @param options.cacheTime
-   * @returns Promise that resolves to an object containing multiple devices
+   * @param {{ cacheTime: number }} options - Options for getting devices, e.g., cache time
+   * @param {number} options.cacheTime - Cache time in seconds
+   * @returns {Promise<MiioDevices>} Promise that resolves to an object containing multiple devices
    */
   export function devices(options: { cacheTime: number }): Promise<MiioDevices>;
 
   /**
    * Browse for miio devices on the local network
    *
-   * @param options - Browse options including cacheTime
-   * @param options.cacheTime
-   * @returns Browser instance for listening to device availability events
+   * @param {{ cacheTime?: number }} options - Browse options including cacheTime
+   * @param {number} [options.cacheTime] - Cache time in seconds
+   * @returns {Browser} Browser instance for listening to device availability events
    */
   export function browse(options: { cacheTime?: number }): Browser;
 

--- a/src/module.ts
+++ b/src/module.ts
@@ -230,6 +230,22 @@ export class TemplatePlatform extends MatterbridgeDynamicPlatform {
           }
         });
 
+      // Start cleaning specific rooms defined in ServiceArea cluster
+      vacuum.addCommandHandler('selectAreas', async (data) => {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        const areas: number[] | undefined = (data.request as any).newAreas;
+        if (Array.isArray(areas) && areas.length > 0) {
+          try {
+            this.log.info(`Vacuum room cleaning request: ${areas.join(', ')}`);
+            await roborock.call('app_segment_clean', areas);
+            await vacuum.updateAttribute(ServiceArea.Cluster.id, 'selectedAreas', areas, this.log);
+          } catch (err) {
+            this.log.error(`Vacuum selectAreas failed: ${String(err)}`);
+            throw err;
+          }
+        }
+      });
+
       await this.registerDevice(vacuum);
 
       // Periodically fetch status from the device and update attributes

--- a/src/types.ts
+++ b/src/types.ts
@@ -122,7 +122,7 @@ export interface IErrorState extends IDeviceState {
 
 export interface IMiResponse {
   id: number;
-  result: [any];
+  result: [unknown];
   error?: {
     code: number;
     message: string;
@@ -132,7 +132,7 @@ export interface IMiResponse {
 export interface IMiCommand {
   // id: number;
   method: string;
-  params?: any[];
+  params?: unknown[];
 }
 
 export interface ISegment {


### PR DESCRIPTION
## Summary
- enable cleaning by selected rooms via ServiceArea cluster
- tighten typings to satisfy ESLint rules
- document miio API params

## Testing
- `npm run build`
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ff12df9c0832b82bcebfbe8893fa4